### PR TITLE
Update the version to 5.1.1-SNAPSHOT

### DIFF
--- a/launcher-dist/pom.xml
+++ b/launcher-dist/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>launcher-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>launcher</artifactId>
     <packaging>jar</packaging>

--- a/launcher-impl/bootstrap/pom.xml
+++ b/launcher-impl/bootstrap/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>launcher-impl</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>bootstrap</artifactId>
     <packaging>jar</packaging>

--- a/launcher-impl/glassfish/pom.xml
+++ b/launcher-impl/glassfish/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>launcher-impl</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>patched-glassfish</artifactId>
     <packaging>jar</packaging>

--- a/launcher-impl/microprofile/config/pom.xml
+++ b/launcher-impl/microprofile/config/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>microprofile</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>microprofile-config</artifactId>
     <packaging>jar</packaging>

--- a/launcher-impl/microprofile/fault-tolerance/pom.xml
+++ b/launcher-impl/microprofile/fault-tolerance/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>microprofile</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>microprofile-fault-tolerance</artifactId>
     <packaging>jar</packaging>

--- a/launcher-impl/microprofile/health/pom.xml
+++ b/launcher-impl/microprofile/health/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>microprofile</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>microprofile-health</artifactId>
     <packaging>jar</packaging>

--- a/launcher-impl/microprofile/jwt-auth/pom.xml
+++ b/launcher-impl/microprofile/jwt-auth/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>microprofile</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>microprofile-jwt-auth</artifactId>
     <packaging>jar</packaging>

--- a/launcher-impl/microprofile/metrics/pom.xml
+++ b/launcher-impl/microprofile/metrics/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>microprofile</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>microprofile-metrics</artifactId>
     <packaging>jar</packaging>

--- a/launcher-impl/microprofile/openapi/pom.xml
+++ b/launcher-impl/microprofile/openapi/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>microprofile</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>microprofile-open-api</artifactId>
     <packaging>jar</packaging>

--- a/launcher-impl/microprofile/pom.xml
+++ b/launcher-impl/microprofile/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>launcher-impl</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>microprofile</artifactId>
     <packaging>pom</packaging>

--- a/launcher-impl/microprofile/rest-client/pom.xml
+++ b/launcher-impl/microprofile/rest-client/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>microprofile</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>microprofile-rest-client</artifactId>
     <packaging>jar</packaging>

--- a/launcher-impl/microprofile/telemetry-tracing/pom.xml
+++ b/launcher-impl/microprofile/telemetry-tracing/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>microprofile</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>microprofile-telemetry-tracing</artifactId>
     <packaging>jar</packaging>

--- a/launcher-impl/pom.xml
+++ b/launcher-impl/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.fujitsu.launcher</groupId>
         <artifactId>launcher-parent</artifactId>
-        <version>5.1-SNAPSHOT</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <artifactId>launcher-impl</artifactId>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.fujitsu.launcher</groupId>
     <artifactId>launcher-parent</artifactId>
-    <version>5.1-SNAPSHOT</version>
+    <version>5.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Launcher Parent</name>


### PR DESCRIPTION
In preparation for a patch release, change the artifact version from `5.1-SNAPSHOT` to `5.1.1-SNAPSHOT`.
Since the patch will be developed on the `5.1.x` branch, the target branch is set to `5.1.x`.