### PR TITLE
Fix incorrect readLine results in handling surrogate pairs

### DIFF
--- a/launcher-impl/glassfish/src/main/java/org/apache/catalina/connector/CoyoteReader.java
+++ b/launcher-impl/glassfish/src/main/java/org/apache/catalina/connector/CoyoteReader.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright 2004 The Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.catalina.connector;
+
+import org.apache.catalina.LogFacade;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+
+import java.util.ResourceBundle;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Coyote implementation of the buffered reader.
+ *
+ * @author Remy Maucherat
+ */
+public class CoyoteReader
+    extends BufferedReader {
+
+
+    // -------------------------------------------------------------- Constants
+
+
+    private static final char[] LINE_SEP = { '\r', '\n' };
+    private static final int MAX_LINE_LENGTH = 4096;
+
+    private static final Logger log = LogFacade.getLogger();
+    private static final ResourceBundle rb = log.getResourceBundle();
+
+    // ----------------------------------------------------- Instance Variables
+
+
+    protected InputBuffer ib;
+
+    protected char[] lineBuffer = null;
+
+
+    // ----------------------------------------------------------- Constructors
+
+
+    public CoyoteReader(InputBuffer ib) {
+        super(ib, 1);
+        this.ib = ib;
+    }
+
+    // --------------------------------------------------------- Public Methods
+
+
+    /**
+    * Prevent cloning the facade.
+    */
+    protected Object clone()
+        throws CloneNotSupportedException {
+        throw new CloneNotSupportedException();
+    }
+
+
+    // -------------------------------------------------------- Package Methods
+
+
+    /**
+     * Clear facade.
+     */
+    void clear() {
+        ib = null;
+    }
+
+
+    // --------------------------------------------------------- Reader Methods
+
+
+    public void close()
+        throws IOException {
+        // Disallow operation if the object has gone out of scope
+        if (ib == null) {
+            throw new IllegalStateException(rb.getString(LogFacade.OBJECT_INVALID_SCOPE_EXCEPTION));
+        }
+        ib.close();
+    }
+
+
+    public int read()
+        throws IOException {
+        // Disallow operation if the object has gone out of scope
+        if (ib == null) {
+            throw new IllegalStateException(rb.getString(LogFacade.OBJECT_INVALID_SCOPE_EXCEPTION));
+        }
+        return ib.read();
+    }
+
+
+    public int read(char[] cbuf)
+        throws IOException {
+        // Disallow operation if the object has gone out of scope
+        if (ib == null) {
+            throw new IllegalStateException(rb.getString(LogFacade.OBJECT_INVALID_SCOPE_EXCEPTION));
+        }
+        return ib.read(cbuf, 0, cbuf.length);
+    }
+
+
+    public int read(char[] cbuf, int off, int len)
+        throws IOException {
+        // Disallow operation if the object has gone out of scope
+        if (ib == null) {
+            throw new IllegalStateException(rb.getString(LogFacade.OBJECT_INVALID_SCOPE_EXCEPTION));
+        }
+        return ib.read(cbuf, off, len);
+    }
+
+
+    public long skip(long n)
+        throws IOException {
+        // Disallow operation if the object has gone out of scope
+        if (ib == null) {
+            throw new IllegalStateException(rb.getString(LogFacade.OBJECT_INVALID_SCOPE_EXCEPTION));
+        }
+        return ib.skip(n);
+    }
+
+
+    public boolean ready()
+        throws IOException {
+        // Disallow operation if the object has gone out of scope
+        if (ib == null) {
+            throw new IllegalStateException(rb.getString(LogFacade.OBJECT_INVALID_SCOPE_EXCEPTION));
+        }
+        return ib.ready();
+    }
+
+
+    public boolean markSupported() {
+        // Disallow operation if the object has gone out of scope
+        if (ib == null) {
+            throw new IllegalStateException(rb.getString(LogFacade.OBJECT_INVALID_SCOPE_EXCEPTION));
+        }
+        return true;
+    }
+
+
+    public void mark(int readAheadLimit)
+        throws IOException {
+        // Disallow operation if the object has gone out of scope
+        if (ib == null) {
+            throw new IllegalStateException(rb.getString(LogFacade.OBJECT_INVALID_SCOPE_EXCEPTION));
+        }
+        ib.mark(readAheadLimit);
+    }
+
+
+    public void reset()
+        throws IOException {
+        // Disallow operation if the object has gone out of scope
+        if (ib == null) {
+            throw new IllegalStateException(rb.getString(LogFacade.OBJECT_INVALID_SCOPE_EXCEPTION));
+        }
+        ib.reset();
+    }
+
+
+    public String readLine()
+        throws IOException {
+
+        // Disallow operation if the object has gone out of scope
+        if (ib == null) {
+            throw new IllegalStateException(rb.getString(LogFacade.OBJECT_INVALID_SCOPE_EXCEPTION));
+        }
+
+        if (lineBuffer == null) {
+            lineBuffer = new char[MAX_LINE_LENGTH];
+        }
+
+        String result = null;
+
+        int pos = 0;
+        int end = -1;
+        int skip = -1;
+        StringBuilder aggregator = null;
+        while (end < 0) {
+            mark(MAX_LINE_LENGTH);
+            while ((pos < MAX_LINE_LENGTH) && (end < 0)) {
+                int nRead = read(lineBuffer, pos, MAX_LINE_LENGTH - pos);
+                if (nRead < 0) {
+                    if (pos == 0 && aggregator == null) {
+                        return null;
+                    }
+                    end = pos;
+                    skip = pos;
+                }
+                for (int i = pos; (i < (pos + nRead)) && (end < 0); i++) {
+                    if (lineBuffer[i] == LINE_SEP[0]) {
+                        end = i;
+                        skip = i + 1;
+                        char nextchar;
+                        if (i == (pos + nRead - 1)) {
+                            nextchar = (char) read();
+                        } else {
+                            nextchar = lineBuffer[i+1];
+                        }
+                        if (nextchar == LINE_SEP[1]) {
+                            skip++;
+                        }
+                    } else if (lineBuffer[i] == LINE_SEP[1]) {
+                        end = i;
+                        skip = i + 1;
+                    }
+                }
+                if (nRead > 0) {
+                    pos += nRead;
+                }
+            }
+            if (end < 0) {
+                if (aggregator == null) {
+                    aggregator = new StringBuilder();
+                }
+                aggregator.append(lineBuffer);
+                pos = 0;
+            } else {
+                reset();
+                if (skip(skip) != skip && log.isLoggable(Level.WARNING)) {
+                    log.log(Level.WARNING, LogFacade.FAILED_SKIP_CHARS_IN_BUFFER, skip);
+                }
+            }
+        }
+
+        if (aggregator == null) {
+            result = new String(lineBuffer, 0, end);
+        } else {
+            aggregator.append(lineBuffer, 0, end);
+            result = aggregator.toString();
+        }
+
+        return result;
+
+    }
+
+
+}

--- a/launcher-impl/glassfish/src/main/java/org/apache/catalina/connector/CoyoteReader.java
+++ b/launcher-impl/glassfish/src/main/java/org/apache/catalina/connector/CoyoteReader.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Fujitsu Limited.
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -195,7 +196,7 @@ public class CoyoteReader
         StringBuilder aggregator = null;
         while (end < 0) {
             mark(MAX_LINE_LENGTH);
-            while ((pos < MAX_LINE_LENGTH) && (end < 0)) {
+            while ((pos < MAX_LINE_LENGTH - 1) && (end < 0)) {
                 int nRead = read(lineBuffer, pos, MAX_LINE_LENGTH - pos);
                 if (nRead < 0) {
                     if (pos == 0 && aggregator == null) {
@@ -230,7 +231,7 @@ public class CoyoteReader
                 if (aggregator == null) {
                     aggregator = new StringBuilder();
                 }
-                aggregator.append(lineBuffer);
+                aggregator.append(lineBuffer, 0, pos);
                 pos = 0;
             } else {
                 reset();


### PR DESCRIPTION
Fixes incorrect `readLine` results in handling surrogate pairs.